### PR TITLE
Fix fluid encoder JEI support not working

### DIFF
--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
@@ -21,15 +21,10 @@ public class JeiPlugin implements IModPlugin {
 
     @Override
     public void register(IModRegistry registry) {
-        System.out.println("[GTE-JEI] Registering Extended Pattern Terminal handler");
-
         // Register our Extended Pattern Terminal handler
         // This uses the public API and works fine since there's no conflict
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(
                 new ExtendedRecipeTransferHandler(),
                 Constants.UNIVERSAL_RECIPE_TRANSFER_UID);
-
-        System.out.println("[GTE-JEI] Registration complete");
-        System.out.println("[GTE-JEI] Native Pattern Terminal handler will be replaced via Mixin");
     }
 }

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
@@ -11,8 +11,8 @@ import mezz.jei.config.Constants;
  * Registers the Extended Pattern Terminal handler directly.
  *
  * Note: The native AE2 Pattern Terminal (ContainerPatternTerm) handler is
- * replaced
- * at runtime via Mixin (see RecipeRegistryMixin) to support fluid encoding.
+ * replaced at runtime via Mixin (see RecipeRegistryMixin) to support fluid
+ * encoding.
  */
 @SuppressWarnings({ "unused" })
 @JEIPlugin

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
@@ -1,7 +1,5 @@
 package com.soliddowant.gregtechenergistics.integration.jei;
 
-import com.soliddowant.gregtechenergistics.gui.ExtendedPatternContainer;
-
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.JEIPlugin;
@@ -12,10 +10,11 @@ import mezz.jei.config.Constants;
  *
  * Registers the Extended Pattern Terminal handler directly.
  *
- * Note: The native AE2 Pattern Terminal (ContainerPatternTerm) handler is replaced
+ * Note: The native AE2 Pattern Terminal (ContainerPatternTerm) handler is
+ * replaced
  * at runtime via Mixin (see RecipeRegistryMixin) to support fluid encoding.
  */
-@SuppressWarnings({ "unused", "rawtypes" })
+@SuppressWarnings({ "unused" })
 @JEIPlugin
 public class JeiPlugin implements IModPlugin {
 

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/JeiPlugin.java
@@ -1,63 +1,35 @@
 package com.soliddowant.gregtechenergistics.integration.jei;
 
-import appeng.container.implementations.ContainerPatternTerm;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ImmutableTable;
 import com.soliddowant.gregtechenergistics.gui.ExtendedPatternContainer;
-import mezz.jei.collect.Table;
+
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.JEIPlugin;
-import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
-import mezz.jei.api.recipe.transfer.IRecipeTransferRegistry;
 import mezz.jei.config.Constants;
-import mezz.jei.recipes.RecipeTransferRegistry;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
-@SuppressWarnings({"unused", "rawtypes"})
+/**
+ * JEI Plugin for GregTech Energistics.
+ *
+ * Registers the Extended Pattern Terminal handler directly.
+ *
+ * Note: The native AE2 Pattern Terminal (ContainerPatternTerm) handler is replaced
+ * at runtime via Mixin (see RecipeRegistryMixin) to support fluid encoding.
+ */
+@SuppressWarnings({ "unused", "rawtypes" })
 @JEIPlugin
 public class JeiPlugin implements IModPlugin {
+
     @Override
-    public void register(IModRegistry registry)
-    {
-        IRecipeTransferRegistry transferRegistry = registry.getRecipeTransferRegistry();
+    public void register(IModRegistry registry) {
+        System.out.println("[GTE-JEI] Registering Extended Pattern Terminal handler");
 
-        // If true, some change to JEI broke this integration
-        if(!(transferRegistry instanceof RecipeTransferRegistry))
-            return;
+        // Register our Extended Pattern Terminal handler
+        // This uses the public API and works fine since there's no conflict
+        registry.getRecipeTransferRegistry().addRecipeTransferHandler(
+                new ExtendedRecipeTransferHandler(),
+                Constants.UNIVERSAL_RECIPE_TRANSFER_UID);
 
-        RecipeTransferRegistry castedTransferRegistry = (RecipeTransferRegistry) transferRegistry;
-
-        // Collect non-ContainerPatternTerm transfer handlers and flag if AE2 has been found
-        // JEE checks if AE2 has been found, but that's not needed as the JVM would throw an exception on the import
-        // of ContainerPatternTerm if AE2 was not present
-        Table<Class<?>, String, IRecipeTransferHandler> collectedRegistry =
-                collectNonPatternTerminals(castedTransferRegistry.getRecipeTransferHandlers());
-
-        collectedRegistry.put(ContainerPatternTerm.class, Constants.UNIVERSAL_RECIPE_TRANSFER_UID,
-                new RecipeTransferHandler());
-        collectedRegistry.put(ExtendedPatternContainer.class, Constants.UNIVERSAL_RECIPE_TRANSFER_UID,
-                new ExtendedRecipeTransferHandler());
-        ReflectionHelper.setPrivateValue(RecipeTransferRegistry.class,
-                (RecipeTransferRegistry) registry.getRecipeTransferRegistry(), collectedRegistry,
-                "recipeTransferHandlers", null);
-    }
-
-    protected static <T, U> Table<Class<?>, T, U> collectNonPatternTerminals(ImmutableTable<Class, T, U> transferHandlers) {
-        Table<Class<?>, T, U> newRegistry = Table.hashBasedTable();
-        for (final ImmutableTable.Cell<Class, T, U> currentCell : transferHandlers.cellSet()) {
-            Class<?> rowKey = currentCell.getRowKey();
-            if(rowKey == null)
-                continue;
-
-            if (currentCell.getRowKey().equals(ContainerPatternTerm.class)) {
-                continue;
-            }
-
-            //noinspection ConstantConditions
-            newRegistry.put(currentCell.getRowKey(), currentCell.getColumnKey(), currentCell.getValue());
-        }
-
-        return newRegistry;
+        System.out.println("[GTE-JEI] Registration complete");
+        System.out.println("[GTE-JEI] Native Pattern Terminal handler will be replaced via Mixin");
     }
 }

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
@@ -176,6 +176,18 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         return fluidEncoder;
     }
 
+    protected static boolean hasAnyFluids(@Nullable FluidStack[] fluids) {
+        if (fluids == null)
+            return false;
+        
+        for (FluidStack fluid : fluids) {
+            if (fluid != null && fluid.amount > 0)
+                return true;
+        }
+        
+        return false;
+    }
+
     public static void transferToTerminal(JEIPacket message, Container con) {
         // Get information about the crafting terminal, and do some checks
         if (!(con instanceof IContainerCraftingPacket))
@@ -200,7 +212,7 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
 
         // If there are fluids, always use processing mode to avoid slot conflicts in
         // crafting mode
-        boolean hasInputFluids = message.inputFluids != null && message.inputFluids.length > 0;
+        boolean hasInputFluids = hasAnyFluids(message.inputFluids);
         boolean preserveSlots = message.isCraftingRecipe && !hasInputFluids;
 
         ItemStack[] inputStacks = mergeStacks(message.inputItems, message.inputFluids, inputAreaSize,
@@ -214,7 +226,7 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         if (message.isCraftingRecipe)
             con.onCraftMatrixChanged(new WrapperInvItemHandler(craftMatrix));
         else {
-            boolean hasOutputFluids = message.outputFluids != null && message.outputFluids.length > 0;
+            boolean hasOutputFluids = hasAnyFluids(message.outputFluids);
             boolean preserveOutputSlots = message.isCraftingRecipe && !hasOutputFluids;
 
             ItemStack[] outputStacks = mergeStacks(message.outputItems, message.outputFluids, outputAreaSize,

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
@@ -39,11 +39,9 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
     public IRecipeTransferError transferRecipe(@Nonnull ContainerPatternTerm container,
             @Nonnull IRecipeLayout recipeLayout, @Nonnull EntityPlayer player,
             boolean maxTransfer, boolean doTransfer) {
-        System.out.println("[GTE-JEI] Transferring recipe to pattern terminal...");
         if (doTransfer)
             performTransfer(container, recipeLayout, player, maxTransfer);
 
-        System.out.println("[GTE-JEI] Recipe transfer complete.");
         return null;
     }
 
@@ -56,20 +54,11 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         FluidStack[] inputFluids = new FluidStack[9];
         FluidStack[] outputFluids = new FluidStack[3];
 
-        IGuiIngredientGroup<FluidStack> fluidGroup = recipeLayout.getFluidStacks();
-        System.out.println("[GTE-JEI] Fluid group: " + (fluidGroup == null ? "NULL" : "present"));
-        if (fluidGroup != null) {
-            System.out.println("[GTE-JEI] Fluid ingredients: " + fluidGroup.getGuiIngredients().size());
-        } else {
-            System.out.println("[GTE-JEI] No fluid ingredients present.");
-        }
-
         // Crafting recipes: preserve slot indices (with JEI's 1-based offset)
         // Processing recipes: fill sequentially (ignore slot indices)
         performTransferWithSlots(recipeLayout.getItemStacks(), inputItems, outputItems, isCraftingRecipe,
                 this::getFirstItemStack);
-        // For fluids, always use processing mode (sequential fill) to avoid slot
-        // conflicts
+        // For fluids, always use processing mode (sequential fill) to avoid slot conflicts
         performTransferWithSlots(recipeLayout.getFluidStacks(), inputFluids, outputFluids, false,
                 this::getFirstFluidStack);
 

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
@@ -58,7 +58,8 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         // Processing recipes: fill sequentially (ignore slot indices)
         performTransferWithSlots(recipeLayout.getItemStacks(), inputItems, outputItems, isCraftingRecipe,
                 this::getFirstItemStack);
-        // For fluids, always use processing mode (sequential fill) to avoid slot conflicts
+        // For fluids, always use processing mode (sequential fill) to avoid slot
+        // conflicts
         performTransferWithSlots(recipeLayout.getFluidStacks(), inputFluids, outputFluids, false,
                 this::getFirstFluidStack);
 
@@ -179,12 +180,12 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
     protected static boolean hasAnyFluids(@Nullable FluidStack[] fluids) {
         if (fluids == null)
             return false;
-        
+
         for (FluidStack fluid : fluids) {
             if (fluid != null && fluid.amount > 0)
                 return true;
         }
-        
+
         return false;
     }
 
@@ -226,11 +227,7 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         if (message.isCraftingRecipe)
             con.onCraftMatrixChanged(new WrapperInvItemHandler(craftMatrix));
         else {
-            boolean hasOutputFluids = hasAnyFluids(message.outputFluids);
-            boolean preserveOutputSlots = message.isCraftingRecipe && !hasOutputFluids;
-
-            ItemStack[] outputStacks = mergeStacks(message.outputItems, message.outputFluids, outputAreaSize,
-                    preserveOutputSlots);
+            ItemStack[] outputStacks = mergeStacks(message.outputItems, message.outputFluids, outputAreaSize, false);
 
             for (int i = 0; i < outputStacks.length && i < outputAreaSize; i++) {
                 ItemStack stack = outputStacks[i];

--- a/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/integration/jei/RecipeTransferHandler.java
@@ -1,6 +1,5 @@
 package com.soliddowant.gregtechenergistics.integration.jei;
 
-import java.util.Map.Entry;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
@@ -40,9 +39,11 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
     public IRecipeTransferError transferRecipe(@Nonnull ContainerPatternTerm container,
             @Nonnull IRecipeLayout recipeLayout, @Nonnull EntityPlayer player,
             boolean maxTransfer, boolean doTransfer) {
+        System.out.println("[GTE-JEI] Transferring recipe to pattern terminal...");
         if (doTransfer)
             performTransfer(container, recipeLayout, player, maxTransfer);
 
+        System.out.println("[GTE-JEI] Recipe transfer complete.");
         return null;
     }
 
@@ -55,11 +56,21 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         FluidStack[] inputFluids = new FluidStack[9];
         FluidStack[] outputFluids = new FluidStack[3];
 
+        IGuiIngredientGroup<FluidStack> fluidGroup = recipeLayout.getFluidStacks();
+        System.out.println("[GTE-JEI] Fluid group: " + (fluidGroup == null ? "NULL" : "present"));
+        if (fluidGroup != null) {
+            System.out.println("[GTE-JEI] Fluid ingredients: " + fluidGroup.getGuiIngredients().size());
+        } else {
+            System.out.println("[GTE-JEI] No fluid ingredients present.");
+        }
+
         // Crafting recipes: preserve slot indices (with JEI's 1-based offset)
         // Processing recipes: fill sequentially (ignore slot indices)
         performTransferWithSlots(recipeLayout.getItemStacks(), inputItems, outputItems, isCraftingRecipe,
                 this::getFirstItemStack);
-        performTransferWithSlots(recipeLayout.getFluidStacks(), inputFluids, outputFluids, isCraftingRecipe,
+        // For fluids, always use processing mode (sequential fill) to avoid slot
+        // conflicts
+        performTransferWithSlots(recipeLayout.getFluidStacks(), inputFluids, outputFluids, false,
                 this::getFirstFluidStack);
 
         NetworkHandler.ServerHandlerChannel.sendToServer(
@@ -73,6 +84,9 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
 
     protected <T> void performTransferWithSlots(IGuiIngredientGroup<T> ingredientGroup,
             T[] inputs, T[] outputs, boolean preserveSlots, Function<Iterable<T>, T> getFirstStack) {
+        if (ingredientGroup == null || ingredientGroup.getGuiIngredients() == null)
+            return;
+
         if (preserveSlots) {
             // Crafting mode: preserve exact slot positions (with JEI 1-based offset
             // correction)
@@ -195,8 +209,13 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         if (!(con instanceof ContainerPatternTerm))
             return;
 
+        // If there are fluids, always use processing mode to avoid slot conflicts in
+        // crafting mode
+        boolean hasInputFluids = message.inputFluids != null && message.inputFluids.length > 0;
+        boolean preserveSlots = message.isCraftingRecipe && !hasInputFluids;
+
         ItemStack[] inputStacks = mergeStacks(message.inputItems, message.inputFluids, inputAreaSize,
-                message.isCraftingRecipe);
+                preserveSlots);
 
         for (int i = 0; i < inputStacks.length && i < inputAreaSize; i++) {
             ItemStack stack = inputStacks[i];
@@ -206,8 +225,11 @@ public class RecipeTransferHandler implements IRecipeTransferHandler<ContainerPa
         if (message.isCraftingRecipe)
             con.onCraftMatrixChanged(new WrapperInvItemHandler(craftMatrix));
         else {
+            boolean hasOutputFluids = message.outputFluids != null && message.outputFluids.length > 0;
+            boolean preserveOutputSlots = message.isCraftingRecipe && !hasOutputFluids;
+
             ItemStack[] outputStacks = mergeStacks(message.outputItems, message.outputFluids, outputAreaSize,
-                    message.isCraftingRecipe);
+                    preserveOutputSlots);
 
             for (int i = 0; i < outputStacks.length && i < outputAreaSize; i++) {
                 ItemStack stack = outputStacks[i];

--- a/src/main/java/com/soliddowant/gregtechenergistics/mixins/GregTechEnergisticsMixinPlugin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/mixins/GregTechEnergisticsMixinPlugin.java
@@ -3,7 +3,7 @@ package com.soliddowant.gregtechenergistics.mixins;
 import java.util.List;
 import java.util.Set;
 
-import org.spongepowered.asm.lib.tree.ClassNode;
+import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
@@ -13,10 +13,13 @@ import net.minecraftforge.fml.common.Loader;
  * Mixin config plugin that conditionally loads mixins based on mod presence.
  * This prevents crashes when optional dependencies like JEI are not installed.
  * 
- * <p>This plugin assumes that JEI-specific mixins are placed in a ".jei" subpackage
+ * <p>
+ * This plugin assumes that JEI-specific mixins are placed in a ".jei"
+ * subpackage
  * under the main mixin package. For example, if the mixin package is
  * "com.soliddowant.gregtechenergistics.mixins", then JEI mixins should be in
- * "com.soliddowant.gregtechenergistics.mixins.jei".</p>
+ * "com.soliddowant.gregtechenergistics.mixins.jei".
+ * </p>
  */
 public class GregTechEnergisticsMixinPlugin implements IMixinConfigPlugin {
 
@@ -43,7 +46,7 @@ public class GregTechEnergisticsMixinPlugin implements IMixinConfigPlugin {
         if (mixinClassName.startsWith(jeiMixinPackage)) {
             return Loader.isModLoaded(JEI_MOD_ID);
         }
-        
+
         // Apply all other mixins unconditionally
         return true;
     }

--- a/src/main/java/com/soliddowant/gregtechenergistics/mixins/GregTechEnergisticsMixinPlugin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/mixins/GregTechEnergisticsMixinPlugin.java
@@ -1,0 +1,71 @@
+package com.soliddowant.gregtechenergistics.mixins;
+
+import java.util.List;
+import java.util.Set;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Mixin config plugin that conditionally loads mixins based on mod presence.
+ * This prevents crashes when optional dependencies like JEI are not installed.
+ * 
+ * <p>This plugin assumes that JEI-specific mixins are placed in a ".jei" subpackage
+ * under the main mixin package. For example, if the mixin package is
+ * "com.soliddowant.gregtechenergistics.mixins", then JEI mixins should be in
+ * "com.soliddowant.gregtechenergistics.mixins.jei".</p>
+ */
+public class GregTechEnergisticsMixinPlugin implements IMixinConfigPlugin {
+
+    private static final String JEI_PACKAGE_SUFFIX = ".jei.";
+    private static final String JEI_MOD_ID = "jei";
+
+    private String mixinPackage;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        this.mixinPackage = mixinPackage;
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // Only gate JEI-related mixins behind JEI presence check
+        // Check if the mixin is in the jei subpackage
+        String jeiMixinPackage = mixinPackage + JEI_PACKAGE_SUFFIX;
+        if (mixinClassName.startsWith(jeiMixinPackage)) {
+            return Loader.isModLoaded(JEI_MOD_ID);
+        }
+        
+        // Apply all other mixins unconditionally
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+        // No special target handling needed
+    }
+
+    @Override
+    public List<String> getMixins() {
+        // Return null to let the config file handle mixin listing
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        // No pre-apply processing needed
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        // No post-apply processing needed
+    }
+}

--- a/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
@@ -1,0 +1,67 @@
+package com.soliddowant.gregtechenergistics.mixins.jei;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.soliddowant.gregtechenergistics.integration.jei.RecipeTransferHandler;
+
+import appeng.container.implementations.ContainerPatternTerm;
+import mezz.jei.api.recipe.IRecipeCategory;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import mezz.jei.recipes.RecipeRegistry;
+import net.minecraft.inventory.Container;
+
+/**
+ * Mixin to override JEI's recipe transfer handler lookup for ContainerPatternTerm.
+ *
+ * This is necessary because RecipeRegistry creates an immutable snapshot of handlers
+ * during construction, so runtime modifications via reflection don't work. AE2's native
+ * JEI handler doesn't support fluid encoding, so we need to replace it with our own.
+ */
+@Mixin(value = RecipeRegistry.class, remap = false)
+public class RecipeRegistryMixin {
+
+    private static RecipeTransferHandler GT_ENERGISTICS_HANDLER = null;
+
+    @Inject(
+        method = "getRecipeTransferHandler",
+        at = @At("RETURN"),
+        cancellable = true,
+        remap = false
+    )
+    private void injectPatternTermHandler(
+            Container container,
+            IRecipeCategory recipeCategory,
+            CallbackInfoReturnable<IRecipeTransferHandler> cir) {
+
+        // Only intercept for ContainerPatternTerm
+        if (!(container instanceof ContainerPatternTerm)) {
+            return;
+        }
+
+        IRecipeTransferHandler originalHandler = cir.getReturnValue();
+
+        // If there's no handler or it's already ours, do nothing
+        if (originalHandler == null) {
+            return;
+        }
+
+        if (originalHandler instanceof RecipeTransferHandler) {
+            return;
+        }
+
+        // Replace AE2's handler with ours (lazy initialization)
+        if (GT_ENERGISTICS_HANDLER == null) {
+            GT_ENERGISTICS_HANDLER = new RecipeTransferHandler();
+            System.out.println("[GTE-JEI-Mixin] Created GregTech Energistics recipe transfer handler for ContainerPatternTerm");
+        }
+
+        System.out.println("[GTE-JEI-Mixin] Replacing " + originalHandler.getClass().getName() +
+                " with " + GT_ENERGISTICS_HANDLER.getClass().getName() +
+                " for recipe category: " + recipeCategory.getUid());
+
+        cir.setReturnValue(GT_ENERGISTICS_HANDLER);
+    }
+}

--- a/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
@@ -29,7 +29,7 @@ import net.minecraft.inventory.Container;
 public abstract class RecipeRegistryMixin {
 
     @Unique
-    private static RecipeTransferHandler GT_ENERGISTICS_HANDLER = null;
+    private static final RecipeTransferHandler GT_ENERGISTICS_HANDLER = new RecipeTransferHandler();
 
     @Inject(method = "getRecipeTransferHandler", at = @At("RETURN"), cancellable = true, remap = false)
     private void injectPatternTermHandler(
@@ -53,11 +53,7 @@ public abstract class RecipeRegistryMixin {
             return;
         }
 
-        // Replace AE2's handler with ours (lazy initialization)
-        if (GT_ENERGISTICS_HANDLER == null) {
-            GT_ENERGISTICS_HANDLER = new RecipeTransferHandler();
-        }
-
+        // Replace AE2's handler with this mod's handler
         cir.setReturnValue(GT_ENERGISTICS_HANDLER);
     }
 }

--- a/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
@@ -1,6 +1,7 @@
 package com.soliddowant.gregtechenergistics.mixins.jei;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -14,23 +15,23 @@ import mezz.jei.recipes.RecipeRegistry;
 import net.minecraft.inventory.Container;
 
 /**
- * Mixin to override JEI's recipe transfer handler lookup for ContainerPatternTerm.
+ * Mixin to override JEI's recipe transfer handler lookup for
+ * ContainerPatternTerm.
  *
- * This is necessary because RecipeRegistry creates an immutable snapshot of handlers
- * during construction, so runtime modifications via reflection don't work. AE2's native
- * JEI handler doesn't support fluid encoding, so we need to replace it with our own.
+ * This is necessary because RecipeRegistry creates an immutable snapshot of
+ * handlers
+ * during construction, so runtime modifications via reflection don't work.
+ * AE2's native
+ * JEI handler doesn't support fluid encoding, so we need to replace it with our
+ * own.
  */
 @Mixin(value = RecipeRegistry.class, remap = false)
-public class RecipeRegistryMixin {
+public abstract class RecipeRegistryMixin {
 
+    @Unique
     private static RecipeTransferHandler GT_ENERGISTICS_HANDLER = null;
 
-    @Inject(
-        method = "getRecipeTransferHandler",
-        at = @At("RETURN"),
-        cancellable = true,
-        remap = false
-    )
+    @Inject(method = "getRecipeTransferHandler", at = @At("RETURN"), cancellable = true, remap = false)
     private void injectPatternTermHandler(
             Container container,
             IRecipeCategory recipeCategory,

--- a/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/mixins/jei/RecipeRegistryMixin.java
@@ -55,12 +55,7 @@ public class RecipeRegistryMixin {
         // Replace AE2's handler with ours (lazy initialization)
         if (GT_ENERGISTICS_HANDLER == null) {
             GT_ENERGISTICS_HANDLER = new RecipeTransferHandler();
-            System.out.println("[GTE-JEI-Mixin] Created GregTech Energistics recipe transfer handler for ContainerPatternTerm");
         }
-
-        System.out.println("[GTE-JEI-Mixin] Replacing " + originalHandler.getClass().getName() +
-                " with " + GT_ENERGISTICS_HANDLER.getClass().getName() +
-                " for recipe category: " + recipeCategory.getUid());
 
         cir.setReturnValue(GT_ENERGISTICS_HANDLER);
     }

--- a/src/main/resources/mixins.gregtechenergistics.json
+++ b/src/main/resources/mixins.gregtechenergistics.json
@@ -4,6 +4,7 @@
   "target": "@env(DEFAULT)",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
+  "plugin": "com.soliddowant.gregtechenergistics.mixins.GregTechEnergisticsMixinPlugin",
   "mixins": [
     "MetaTileEntityHolderMixin"
   ],

--- a/src/main/resources/mixins.gregtechenergistics.json
+++ b/src/main/resources/mixins.gregtechenergistics.json
@@ -10,7 +10,8 @@
   "client": [
     "GuiCraftingStatusMixin",
     "ItemEncodedPatternMixin",
-    "RenderItemOverlayMixin"
+    "RenderItemOverlayMixin",
+    "jei.RecipeRegistryMixin"
   ],
   "server": []
 }


### PR DESCRIPTION
JEI's "Move Items" button failed to transfer fluids to the native AE2 Pattern Terminal when EnderCore/EnderIO was present. Fluids were completely omitted from the pattern, while items worked correctly. The Extended Pattern Terminal was unaffected.

### Root Cause

JEI's RecipeRegistry creates an immutable snapshot of recipe transfer handlers during construction. The original approach attempted to replace AE2's handler via reflection by modifying RecipeTransferRegistry, but this had two fatal flaws:
                                                                                                                                                                                                                        
1. Non-deterministic plugin load order: JEI loads `@JEIPlugin` classes in an undefined order (from `ASMDataTable.getAll()` which returns an unordered `Set`). Sometimes our plugin loaded before AE2's, sometimes after.
2. Immutable handler cache: Even when the source registry was successfully modified via reflection, `RecipeRegistry` already held a frozen `ImmutableTable` snapshot taken during startup. Runtime modifications were never seen by the actual handler lookup code.

### Solution

Implemented a Mixin (`RecipeRegistryMixin`) that intercepts `RecipeRegistry.getRecipeTransferHandler()` at runtime:

* Detects when the lookup is for `ContainerPatternTerm`
* Replaces AE2's fluid-unaware handler with our custom handler that converts fluids to fluid encoder items
* Works regardless of plugin load order since it intercepts the actual runtime lookup

### Changes

1. Added RecipeRegistryMixin.java - Mixin that intercepts handler lookups
2. Simplified JeiPlugin.java - Removed complex reflection code, now only registers Extended Pattern Terminal handler
3. Fixed RecipeTransferHandler.java - Force processing mode for fluids to avoid slot conflicts
4. Updated mixins.gregtechenergistics.json - Registered the new mixin

### Testing                                                                                                                                                                                                                 
                                                                                                                                                                                                                        
Verified with EnderCore/EnderIO enabled across multiple restarts - fluids now consistently appear as fluid encoder items when using JEI's "Move Items" button on the native AE2 Pattern Terminal.