### PR TITLE
Fix fluid encoder quantity being wrong periodically when loading from JEI

### DIFF
--- a/src/main/java/com/soliddowant/gregtechenergistics/items/behaviors/FluidEncoderBehaviour.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/items/behaviors/FluidEncoderBehaviour.java
@@ -135,7 +135,12 @@ public class FluidEncoderBehaviour implements IItemBehaviour, ItemUIFactory {
 
         NBTTagCompound tag = stack.hasTagCompound() ? stack.getTagCompound() : new NBTTagCompound();
         NBTTagCompound fluidTag = new NBTTagCompound();
-        fluid.writeToNBT(fluidTag);
+
+        // Create a copy with normalized amount to avoid race conditions with shared FluidStack objects
+        // The actual amount is stored separately in the "Amount" tag
+        FluidStack normalizedFluid = new FluidStack(fluid, 1000);
+        normalizedFluid.writeToNBT(fluidTag);
+
         tag.setTag("FluidStack", fluidTag);
         stack.setTagCompound(tag);
     }


### PR DESCRIPTION
Sometimes when using JEI's "Move Items" button to transfer a recipe into a pattern terminal, the created fluid encoder items would contain the wrong fluid volume. This seems to impact fluid solidifier rotor recipes specifically for some reason, as well as other fluid recipes periodically. This PR seems to fix the issue, but I'll need to test more locally to confirm.