### PR TITLE
Add stocker machine highlighting to terminal

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,6 +44,7 @@ dependencies {
     api(rfg.deobf("curse.maven:ae2-extended-life-570458:6302098-deobf-sources-api"))
 
     // Compile-only API dependencies - available at compiletime for depending mods, optional at runtime
+    // compileOnlyApi(rfg.deobf("curse.maven:mousetweaks-60089:2671937-sources-2671939-api-3359845"))
 
     // // Compile-only dependencies - optional integrations, not available to depending mods
     // compileOnly(rfg.deobf("curse.maven:groovyscript-687577:4431117-deobf-sources"))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -41,10 +41,9 @@ dependencies {
     // Core API dependencies - required at compile and runtime, published as Maven dependencies
     api(rfg.deobf("curse.maven:codechickenlib-242818:2779848-deobf-sources"))
     api(rfg.deobf("curse.maven:gregtech-nomifactory-edition-1019238:7064114-deobf-sources"))
-    api(rfg.deobf("curse.maven:ae2-extended-life-570458:5035908-deobf-sources-api"))
+    api(rfg.deobf("curse.maven:ae2-extended-life-570458:6302098-deobf-sources-api"))
 
     // Compile-only API dependencies - available at compiletime for depending mods, optional at runtime
-    compileOnlyApi(rfg.deobf("curse.maven:mousetweaks-60089:2671937-sources-2671939-api-3359845"))
 
     // // Compile-only dependencies - optional integrations, not available to depending mods
     // compileOnly(rfg.deobf("curse.maven:groovyscript-687577:4431117-deobf-sources"))

--- a/src/api/java/yalter/mousetweaks/api/IMTModGuiContainer2.java
+++ b/src/api/java/yalter/mousetweaks/api/IMTModGuiContainer2.java
@@ -1,0 +1,87 @@
+package yalter.mousetweaks.api;
+
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+
+/**
+ * This is the interface you want to implement in your GuiScreen to make it compatible with Mouse Tweaks.
+ * If this interface is not enough (for example, you need a custom slot click function, or if you use a custom Container
+ * which happens to be incompatible), check IMTModGuiContainer2Ex instead.
+ * If you just need to disable Mouse Tweaks or the wheel tweak, see the MouseTweaksIgnore
+ * or the MouseTweaksDisableWheelTweak annotations.
+ */
+public interface IMTModGuiContainer2 {
+    /**
+     * If you want to disable Mouse Tweaks in your GuiScreen, return true from this method.
+     *
+     * @return True if Mouse Tweaks should be disabled, false otherwise.
+     */
+    boolean MT_isMouseTweaksDisabled();
+
+    /**
+     * If you want to disable the Wheel Tweak in your GuiScreen, return true from this method.
+     *
+     * @return True if the Wheel Tweak should be disabled, false otherwise.
+     */
+    boolean MT_isWheelTweakDisabled();
+
+    /**
+     * Returns the Container.
+     *
+     * @return Container that is currently in use.
+     */
+    Container MT_getContainer();
+
+    /**
+     * Returns the Slot that is currently selected by the player, or null if no Slot is selected.
+     *
+     * @return Slot that is located under the mouse, or null if no Slot it currently under the mouse.
+     */
+    Slot MT_getSlotUnderMouse();
+
+    /**
+     * Return true if the given Slot behaves like the vanilla crafting output slots (inside the crafting table,
+     * or the furnace output slot, or the anvil output slot, etc.). These slots are handled differently by Mouse Tweaks.
+     *
+     * @param slot the slot to check
+     * @return True if slot is a crafting output slot.
+     */
+    boolean MT_isCraftingOutput(Slot slot);
+
+    /**
+     * Return true if the given Slot should be ignored by Mouse Tweaks. Examples of ignored slots are the item select
+     * slots and the Destroy Item slot in the vanilla creative inventory.
+     *
+     * @param slot the slot to check
+     * @return Tru if slot should be ignored by Mouse Tweaks.
+     */
+    boolean MT_isIgnored(Slot slot);
+
+    /**
+     * If your container has an RMB dragging functionality (like vanilla containers), disable it inside this method.
+     * This method is called every frame (render tick), which is after all mouseClicked / mouseClickMove / mouseReleased
+     * events are handled (although note these events are handled every game tick, which is far less frequent than every
+     * render tick).<br><br>
+     * <p>
+     * If true is returned from this method, Mouse Tweaks (after checking other conditions like isIgnored) will click
+     * the slot on which the right mouse button was initially pressed (in most cases this is the slot currently under
+     * mouse). This is needed because the vanilla RMB dragging functionality prevents the initial slot click.<br><br>
+     * <p>
+     * For vanilla containers this method looks like this:
+     * <pre>
+     * this.ignoreMouseUp = true;
+     *
+     * if (this.dragSplitting) {
+     *     if (this.dragSplittingButton == 1) {
+     *         this.dragSplitting = false;
+     *         return true;
+     *     }
+     * }
+     *
+     * return false;
+     * </pre>
+     *
+     * @return True if Mouse Tweaks should click the slot on which the RMB was pressed.
+     */
+    boolean MT_disableRMBDraggingFunctionality();
+}

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalContainer.java
@@ -34,6 +34,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
@@ -294,12 +295,21 @@ public class StockerTerminalContainer extends AEBaseContainer {
         setItemTag(data, tag, inv);
     }
 
+    protected void updateTagCoverPosition(NBTTagCompound data, InvTracker inv) {
+        final NBTTagCompound tag = getItemTag(data, inv);
+        BlockPos pos = inv.cover.coverHolder.getPos();
+        tag.setTag("pos", NBTUtil.createPosTag(pos));
+        tag.setInteger("dim", inv.cover.coverHolder.getWorld().provider.getDimension());
+        setItemTag(data, tag, inv);
+    }
+
     protected void buildStockerTag(final NBTTagCompound data, final Entry<CoverAE2Stocker, InvTracker> en,
             @SuppressWarnings("SameParameterValue") final int offset, final int length) {
         InvTracker invTracker = en.getValue();
 
         updateTagChildItems(data, invTracker, offset, length);
         updateTagCoverStatus(data, invTracker);
+        updateTagCoverPosition(data, invTracker);
     }
 
     protected static class InvTracker {

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalContainer.java
@@ -297,9 +297,18 @@ public class StockerTerminalContainer extends AEBaseContainer {
 
     protected void updateTagCoverPosition(NBTTagCompound data, InvTracker inv) {
         final NBTTagCompound tag = getItemTag(data, inv);
-        BlockPos pos = inv.cover.coverHolder.getPos();
-        tag.setTag("pos", NBTUtil.createPosTag(pos));
-        tag.setInteger("dim", inv.cover.coverHolder.getWorld().provider.getDimension());
+
+        // Safety check: only add position if coverHolder and world are valid
+        if (inv.cover != null && inv.cover.coverHolder != null) {
+            BlockPos pos = inv.cover.coverHolder.getPos();
+            if (pos != null)
+                tag.setTag("pos", NBTUtil.createPosTag(pos));
+
+            World world = inv.cover.coverHolder.getWorld();
+            if (world != null && world.provider != null)
+                tag.setInteger("dim", world.provider.getDimension());
+        }
+
         setItemTag(data, tag, inv);
     }
 

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
@@ -1,5 +1,6 @@
 package com.soliddowant.gregtechenergistics.gui;
 
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,9 +43,9 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
-import java.awt.Rectangle;
 
 public class StockerTerminalGuiContainer extends AEBaseGui {
 	protected final int offsetX = 9;
@@ -150,8 +151,7 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 
 		// Create exclusion areas for all potential highlight button positions
 		// Buttons are positioned at guiLeft - 18, with Y positions starting at guiTop +
-		// 18
-		// and incrementing by 18 for each of the 6 visible lines
+		// 18 and incrementing by 18 for each of the 6 visible lines
 		int offset = 17;
 		for (int x = 0; x < LINES_ON_PAGE; x++) {
 			// Each button is 16x16 pixels, positioned at (guiLeft - 18, guiTop + offset +
@@ -208,16 +208,20 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 		// Check if different dimension
 		if (playerDim != stockerDim) {
 			// Show error message
-			try {
-				this.mc.player.sendMessage(
-						PlayerMessages.InterfaceInOtherDimParam.get(
-								stockerDim,
-								DimensionManager.getWorld(stockerDim).provider.getDimensionType().getName()));
-			} catch (Exception e) {
-				this.mc.player.sendMessage(
-						PlayerMessages.InterfaceInOtherDim.get());
+			ITextComponent message = PlayerMessages.InterfaceInOtherDim.get();
+
+			// Show the dimension name if possible
+			World stockerWorld = DimensionManager.getWorld(stockerDim);
+			if (stockerWorld != null
+					&& stockerWorld.provider != null
+					&& stockerWorld.provider.getDimensionType() != null) {
+				String dimensionName = stockerWorld.provider.getDimensionType().getName();
+				message = PlayerMessages.InterfaceInOtherDimParam.get(stockerDim, dimensionName);
 			}
+
+			this.mc.player.sendMessage(message);
 			this.mc.player.closeScreen();
+
 			return;
 		}
 

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
@@ -15,15 +15,22 @@ import com.soliddowant.gregtechenergistics.covers.CoverStatus;
 import com.soliddowant.gregtechenergistics.parts.StockerTerminalPart;
 
 import appeng.api.AEApi;
+import appeng.api.config.ActionItems;
+import appeng.api.config.Settings;
 import appeng.api.storage.channels.IItemStorageChannel;
 import appeng.api.util.AEPartLocation;
 import appeng.client.gui.AEBaseGui;
+import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.GuiScrollbar;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.client.me.ClientDCInternalInv;
 import appeng.client.me.SlotDisconnected;
+import appeng.client.render.BlockPosHighlighter;
+import appeng.core.localization.PlayerMessages;
+import appeng.util.BlockPosUtils;
 import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -31,8 +38,11 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
 
 public class StockerTerminalGuiContainer extends AEBaseGui {
 	protected final int offsetX = 9;
@@ -43,6 +53,11 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 	protected final ArrayList<Object> lines = new ArrayList<>();
 	protected final HashMultimap<String, StockerInformation> byName = HashMultimap.create();
 	protected final ArrayList<String> names = new ArrayList<>();
+
+	// Position tracking for highlighting
+	protected final HashMap<StockerInformation, BlockPos> blockPosHashMap = new HashMap<>();
+	protected final HashMap<StockerInformation, Integer> dimHashMap = new HashMap<>();
+	protected final HashMap<GuiButton, StockerInformation> guiButtonHashMap = new HashMap<>();
 
 	protected boolean refreshList = false;
 	protected final Map<String, Set<Object>> cachedSearches = new WeakHashMap<>();
@@ -75,6 +90,10 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 
 	@Override
 	public void drawFG(final int offsetX, final int offsetY, final int mouseX, final int mouseY) {
+		// Clear old buttons
+		this.buttonList.removeIf(button -> guiButtonHashMap.containsKey(button));
+		this.guiButtonHashMap.clear();
+
 		this.fontRenderer.drawString(I18n.format("gui.gregtechenergistics.terminal.stocker"),
 				8, 6, 4210752);
 		this.fontRenderer.drawString(I18n.format("gui.gregtechenergistics.terminal.inventory"),
@@ -89,6 +108,16 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 			final Object lineObj = this.lines.get(ex + x);
 			if (lineObj instanceof StockerInformation) {
 				final StockerInformation stockerInformation = (StockerInformation) lineObj;
+
+				// Create highlight button
+				GuiButton highlightButton = new GuiImgButton(
+						this.guiLeft + 4,
+						this.guiTop + offset + 1,
+						Settings.ACTIONS,
+						ActionItems.HIGHLIGHT_INTERFACE);
+				guiButtonHashMap.put(highlightButton, stockerInformation);
+				this.buttonList.add(highlightButton);
+
 				this.inventorySlots.inventorySlots
 						.add(new SlotDisconnected(stockerInformation.patternInventory, 0, 10, 1 + offset));
 
@@ -123,6 +152,59 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 		}
 
 		super.mouseClicked(xCoord, yCoord, btn);
+	}
+
+	@Override
+	protected void actionPerformed(final GuiButton btn) throws IOException {
+		// Not a highlight button - delegate to parent
+		if (!guiButtonHashMap.containsKey(btn)) {
+			super.actionPerformed(btn);
+			return;
+		}
+
+		StockerInformation stockerInfo = guiButtonHashMap.get(btn);
+		BlockPos blockPos = blockPosHashMap.get(stockerInfo);
+
+		// Missing position data - do nothing
+		if (blockPos == null)
+			return;
+
+		Integer stockerDim = dimHashMap.get(stockerInfo);
+
+		// Missing dimension data - do nothing
+		if (stockerDim == null)
+			return;
+
+		BlockPos playerPos = this.mc.player.getPosition();
+		int playerDim = this.mc.world.provider.getDimension();
+
+		// Check if different dimension
+		if (playerDim != stockerDim) {
+			// Show error message
+			try {
+				this.mc.player.sendMessage(
+						PlayerMessages.InterfaceInOtherDimParam.get(
+								stockerDim,
+								DimensionManager.getWorld(stockerDim).provider.getDimensionType().getName()));
+			} catch (Exception e) {
+				this.mc.player.sendMessage(
+						PlayerMessages.InterfaceInOtherDim.get());
+			}
+			this.mc.player.closeScreen();
+			return;
+		}
+
+		// Same dimension - highlight the block
+		long timeout = System.currentTimeMillis() + 500 * BlockPosUtils.getDistance(blockPos, playerPos);
+		BlockPosHighlighter.hilightBlock(blockPos, timeout, playerDim);
+
+		this.mc.player.sendMessage(
+				PlayerMessages.InterfaceHighlighted.get(
+						blockPos.getX(),
+						blockPos.getY(),
+						blockPos.getZ()));
+
+		this.mc.player.closeScreen();
 	}
 
 	@Override
@@ -197,6 +279,12 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 					current.availableCount = invData.getLong("availableCount");
 					current.stockCount = invData.getLong("stockCount");
 					current.status = CoverStatus.values()[invData.getInteger("status")];
+
+					// Extract position and dimension data
+					if (invData.hasKey("pos"))
+						blockPosHashMap.put(current, NBTUtil.getPosFromTag(invData.getCompoundTag("pos")));
+					if (invData.hasKey("dim"))
+						dimHashMap.put(current, invData.getInteger("dim"));
 				} catch (final NumberFormatException ignored) {
 				}
 			}

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
@@ -111,7 +111,7 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 
 				// Create highlight button
 				GuiButton highlightButton = new GuiImgButton(
-						this.guiLeft + 4,
+						this.guiLeft - 18,
 						this.guiTop + offset + 1,
 						Settings.ACTIONS,
 						ActionItems.HIGHLIGHT_INTERFACE);

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
@@ -289,44 +289,47 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 
 		for (final Object oKey : in.getKeySet()) {
 			final String key = (String) oKey;
-			if (key.startsWith("=")) {
-				try {
-					final long id = Long.parseLong(key.substring(1), Character.MAX_RADIX);
-					final NBTTagCompound invData = in.getCompoundTag(key);
-					final StockerInformation current = this.getById(id, invData);
+			if (!key.startsWith("="))
+				continue;
 
-					for (int x = 0; x < current.patternInventory.getInventory().getSlots(); x++) {
-						final String which = Integer.toString(x);
-						if (invData.hasKey(which)) {
-							NBTTagCompound stackNBT = invData.getCompoundTag(which);
-							// If the NBT is empty, it means the slot should be cleared
-							if (stackNBT.isEmpty())
-								current.patternInventory.getInventory().setStackInSlot(x, ItemStack.EMPTY);
-							else
-								current.patternInventory.getInventory().setStackInSlot(x, new ItemStack(stackNBT));
-						}
-					}
+			try {
+				final long id = Long.parseLong(key.substring(1), Character.MAX_RADIX);
+				final NBTTagCompound invData = in.getCompoundTag(key);
+				final StockerInformation current = this.getById(id, invData);
 
-					current.availableCount = invData.getLong("availableCount");
-					current.stockCount = invData.getLong("stockCount");
-					current.status = CoverStatus.values()[invData.getInteger("status")];
+				for (int x = 0; x < current.patternInventory.getInventory().getSlots(); x++) {
+					final String which = Integer.toString(x);
+					if (!invData.hasKey(which))
+						continue;
 
-					// Extract position and dimension data
-					if (invData.hasKey("pos"))
-						blockPosHashMap.put(current, NBTUtil.getPosFromTag(invData.getCompoundTag("pos")));
-					if (invData.hasKey("dim"))
-						dimHashMap.put(current, invData.getInteger("dim"));
-				} catch (final NumberFormatException ignored) {
+					NBTTagCompound stackNBT = invData.getCompoundTag(which);
+					// If the NBT is empty, it means the slot should be cleared
+					if (stackNBT.isEmpty())
+						current.patternInventory.getInventory().setStackInSlot(x, ItemStack.EMPTY);
+					else
+						current.patternInventory.getInventory().setStackInSlot(x, new ItemStack(stackNBT));
 				}
+
+				current.availableCount = invData.getLong("availableCount");
+				current.stockCount = invData.getLong("stockCount");
+				current.status = CoverStatus.values()[invData.getInteger("status")];
+
+				// Extract position and dimension data
+				if (invData.hasKey("pos"))
+					blockPosHashMap.put(current, NBTUtil.getPosFromTag(invData.getCompoundTag("pos")));
+				if (invData.hasKey("dim"))
+					dimHashMap.put(current, invData.getInteger("dim"));
+			} catch (final NumberFormatException ignored) {
 			}
 		}
 
-		if (this.refreshList) {
-			this.refreshList = false;
-			// invalid caches on refresh
-			this.cachedSearches.clear();
-			this.refreshList();
-		}
+		if (!this.refreshList)
+			return;
+
+		this.refreshList = false;
+		// invalid caches on refresh
+		this.cachedSearches.clear();
+		this.refreshList();
 	}
 
 	/**

--- a/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/gui/StockerTerminalGuiContainer.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -43,6 +44,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
+import java.awt.Rectangle;
 
 public class StockerTerminalGuiContainer extends AEBaseGui {
 	protected final int offsetX = 9;
@@ -140,6 +142,31 @@ public class StockerTerminalGuiContainer extends AEBaseGui {
 			}
 			offset += 18;
 		}
+	}
+
+	@Override
+	public List<Rectangle> getJEIExclusionArea() {
+		List<Rectangle> exclusionAreas = new ArrayList<>();
+
+		// Create exclusion areas for all potential highlight button positions
+		// Buttons are positioned at guiLeft - 18, with Y positions starting at guiTop +
+		// 18
+		// and incrementing by 18 for each of the 6 visible lines
+		int offset = 17;
+		for (int x = 0; x < LINES_ON_PAGE; x++) {
+			// Each button is 16x16 pixels, positioned at (guiLeft - 18, guiTop + offset +
+			// 1)
+			// Add 2 pixels padding to ensure JEI doesn't overlap
+			Rectangle buttonArea = new Rectangle(
+					this.guiLeft - 18,
+					this.guiTop + offset + 1,
+					18,
+					18);
+			exclusionAreas.add(buttonArea);
+			offset += 18;
+		}
+
+		return exclusionAreas;
 	}
 
 	@Override


### PR DESCRIPTION
This adds a "highlight" button to the stocker terminal, similar to the interface terminal. When clicked, it will draw a red wireframe box around the machine that a stocker terminal is attached to in the world, and print its coordinates.