### PR TITLE
Fix NPE on removing cover from air collector

### DIFF
--- a/src/main/java/com/soliddowant/gregtechenergistics/covers/CoverAE2Stocker.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/covers/CoverAE2Stocker.java
@@ -304,8 +304,11 @@ public class CoverAE2Stocker extends PlayerPlacedCoverBehavior
     public void onRemoved() {
         node.destroy();
 
-        if (doesOtherAllowsWorking)
-            getControllable().setWorkingEnabled(true);
+        if (doesOtherAllowsWorking) {
+            IControllable controllable = getControllable();
+            if (controllable != null)
+                controllable.setWorkingEnabled(true);
+        }
 
         NonNullList<ItemStack> drops = NonNullList.create();
         MetaTileEntity.clearInventory(drops, patternSlotWidget.getSlotHandler());


### PR DESCRIPTION
Forgot a capability check which can cause an exception and/or crash upon cover removal.