### PR TITLE
Work around GTNE large memory leak for large factories

### DIFF
--- a/src/main/java/com/soliddowant/gregtechenergistics/covers/CoverAE2Stocker.java
+++ b/src/main/java/com/soliddowant/gregtechenergistics/covers/CoverAE2Stocker.java
@@ -947,8 +947,12 @@ public class CoverAE2Stocker extends PlayerPlacedCoverBehavior
 
     public void setWorkingStatus(boolean shouldWork) {
         IControllable machine = getControllable();
-        if (machine != null)
-            machine.setWorkingEnabled(shouldWork);
+        // Only call setWorkingEnabled if the state actually needs to change
+        // This prevents excessive writeCustomData calls that cause memory leaks
+        if (machine == null || machine.isWorkingEnabled() == shouldWork)
+            return;
+
+        machine.setWorkingEnabled(shouldWork);
     }
 
     @MENetworkEventSubscribe


### PR DESCRIPTION
Calling `setWorkingEnabled` on `IControllable` GTNE machines always triggers an update packet, even if there is no actual change (old state == new state). On large factories with a cover update rate of 1 update:1 tick, this can cause update packets to be produced faster than they are sent between the client and server. This causes the update packets to never be released from memory, causing a quickly growing memory leak (10s of GB per second in some cases). Work around the issue by only making the `set` call if an update is actually needed.

I've asked the GTNE dev to look into adding this to GTNE directly, which would negate the need for this check. This issue also affects other GTNE functions and causes a much smaller (1/1,000,000x) memory leak without this mod.